### PR TITLE
WIP: make RFTools screens take our variable cards

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -23,3 +23,5 @@ refinedstorage_version=1.5.9-1241
 ie_version=0.12-64-171
 crafttweakerapi_version=4.0.6.261
 crafttweakermain_version=1.12-4.0.6.261
+mcjtylib_version=1.12-2.4.5-SNAPSHOT
+rftools_version=1.12-7.13

--- a/gradle/forge.gradle
+++ b/gradle/forge.gradle
@@ -49,6 +49,10 @@ repositories {
         name 'K4 maven'
         url "http://maven.k-4u.nl/"
     }
+    maven {
+        name 'OC Repo'
+        url "http://maven.cil.li/"
+    }
 }
 dependencies {
     // Add something like 'integrateddynamics_version_local=0.1.0-DEV' to your gradle.properties if you want to use a custom local Integrated Dynamics version.
@@ -83,6 +87,8 @@ dependencies {
     deobfCompile "refinedstorage:refinedstorage:${config.refinedstorage_version}" // https://dl.bintray.com/raoulvdberge/dev/refinedstorage/refinedstorage/
     deobfCompile "blusunrize:ImmersiveEngineering:${config.ie_version}"// http://maven.blamejared.com/blusunrize/ImmersiveEngineering/
     deobfCompile "CraftTweaker2:CraftTweaker2-API:${config.crafttweakerapi_version}"; // http://maven.blamejared.com/CraftTweaker2/CraftTweaker2-API/
+    deobfCompile "com.github.mcjty:mcjtylib:${config.mcjtylib_version}"; // http://maven.k-4u.nl/com/github/mcjty/mcjtylib/
+    deobfCompile "com.github.mcjty:rftools:${config.rftools_version}"; // http://maven.k-4u.nl/com/github/mcjty/rftools/
 
     // Only needed for testing
     //deobfCompile "pl.asie.charset:charset-lib:${config.charset_version}" // http://charset.asie.pl/maven/pl/asie/charset/charset-lib/maven-metadata.xml

--- a/src/main/java/org/cyclops/integrateddynamicscompat/IntegratedDynamicsCompat.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/IntegratedDynamicsCompat.java
@@ -27,6 +27,7 @@ import org.cyclops.integrateddynamicscompat.modcompat.jei.JEIModCompat;
 import org.cyclops.integrateddynamicscompat.modcompat.minetweaker.CraftTweakerModCompat;
 import org.cyclops.integrateddynamicscompat.modcompat.refinedstorage.RefinedStorageModCompat;
 import org.cyclops.integrateddynamicscompat.modcompat.tconstruct.TConstructModCompat;
+import org.cyclops.integrateddynamicscompat.modcompat.rftools.RFToolsModCompat;
 import org.cyclops.integrateddynamicscompat.modcompat.tesla.TeslaApiCompat;
 import org.cyclops.integrateddynamicscompat.modcompat.tesla.capabilities.*;
 import org.cyclops.integrateddynamicscompat.modcompat.top.TopModCompat;
@@ -87,6 +88,7 @@ public class IntegratedDynamicsCompat extends ModBaseVersionable {
         modCompatLoader.addModCompat(new RefinedStorageModCompat());
         modCompatLoader.addModCompat(new ImmersiveEngineeringModCompat());
         modCompatLoader.addModCompat(new CraftTweakerModCompat());
+        modCompatLoader.addModCompat(new RFToolsModCompat());
     }
 
     /**

--- a/src/main/java/org/cyclops/integrateddynamicscompat/Reference.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/Reference.java
@@ -36,6 +36,7 @@ public class Reference {
     public static final String MOD_CYCLOPSCORE_VERSION_MIN = "0.10.22";
     public static final String MOD_INTEGRATEDDYNAMICS = "integrateddynamics";
     public static final String MOD_CRAFTTWEAKER = "crafttweaker";
+    public static final String MOD_RFTOOLS = "rftools";
     
     // Dependencies
     public static final String MOD_DEPENDENCIES =

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/CableNetworkCapabilityProvider.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/CableNetworkCapabilityProvider.java
@@ -1,0 +1,57 @@
+package org.cyclops.integrateddynamicscompat.modcompat.rftools;
+
+import org.cyclops.integrateddynamics.api.network.INetworkCarrier;
+import org.cyclops.integrateddynamics.api.path.IPathElement;
+import org.cyclops.integrateddynamics.capability.cable.CableConfig;
+import org.cyclops.integrateddynamics.capability.network.NetworkCarrierConfig;
+import org.cyclops.integrateddynamics.capability.network.NetworkCarrierDefault;
+import org.cyclops.integrateddynamics.capability.path.PathElementConfig;
+import org.cyclops.integrateddynamics.capability.path.PathElementTile;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+
+public class CableNetworkCapabilityProvider implements ICapabilityProvider, ICapabilitySerializable<NBTTagCompound> {
+	public final CableScreen cable;
+	public final INetworkCarrier networkCarrier;
+	public final IPathElement pathElement;
+
+	public CableNetworkCapabilityProvider(TileEntity tile) {
+		cable = new CableScreen(tile);
+		networkCarrier = new NetworkCarrierDefault();
+		pathElement = new PathElementTile<TileEntity>(tile, cable);
+	}
+
+	@Override
+	public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
+		return capability == CableConfig.CAPABILITY || capability == NetworkCarrierConfig.CAPABILITY || capability == PathElementConfig.CAPABILITY;
+	}
+
+	@Override
+	public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
+		if(capability == CableConfig.CAPABILITY)
+			return (T)cable;
+		else if(capability == NetworkCarrierConfig.CAPABILITY)
+			return (T)networkCarrier;
+		else if(capability == PathElementConfig.CAPABILITY)
+			return (T)pathElement;
+		else
+			return null;
+	}
+
+	@Override
+	public NBTTagCompound serializeNBT() {
+		NBTTagCompound nbt = new NBTTagCompound();
+		cable.writeGeneratedFieldsToNBT(nbt);
+		return nbt;
+	}
+
+	@Override
+	public void deserializeNBT(NBTTagCompound nbt) {
+		cable.readGeneratedFieldsFromNBT(nbt);
+	}
+}

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/CableScreen.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/CableScreen.java
@@ -1,0 +1,105 @@
+package org.cyclops.integrateddynamicscompat.modcompat.rftools;
+
+import org.cyclops.cyclopscore.datastructure.EnumFacingMap;
+import org.cyclops.cyclopscore.helper.BlockHelpers;
+import org.cyclops.cyclopscore.persist.nbt.INBTProvider;
+import org.cyclops.cyclopscore.persist.nbt.NBTPersist;
+import org.cyclops.cyclopscore.persist.nbt.NBTProviderComponent;
+import org.cyclops.integrateddynamics.api.block.cable.ICable;
+import org.cyclops.integrateddynamics.capability.cable.CableDefault;
+
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
+import mcjty.rftools.blocks.screens.ScreenHitTileEntity;
+import mcjty.rftools.blocks.screens.ScreenTileEntity;
+import net.minecraft.init.Blocks;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+@RequiredArgsConstructor
+public class CableScreen extends CableDefault implements INBTProvider {
+	private final TileEntity tile;
+	
+	@Delegate
+    private INBTProvider nbtProviderComponent = new NBTProviderComponent(this);
+
+	@NBTPersist
+	private EnumFacingMap<Boolean> connected = EnumFacingMap.newMap();
+
+	private ScreenTileEntity getScreenTile() {
+		if(tile instanceof ScreenTileEntity) return (ScreenTileEntity) tile;
+		if(!(tile instanceof ScreenHitTileEntity)) return null;
+		ScreenHitTileEntity screenHit = (ScreenHitTileEntity) tile;
+		TileEntity screen = tile.getWorld().getTileEntity(tile.getPos().add(screenHit.getDx(), screenHit.getDy(), screenHit.getDz()));
+		return screen instanceof ScreenTileEntity ? (ScreenTileEntity)screen : null;
+	}
+
+	@Override
+	public boolean canConnect(ICable connector, EnumFacing side) {
+		if(!super.canConnect(connector, side)) return false;
+		ScreenTileEntity screenTile = getScreenTile();
+		if(screenTile != null && connector instanceof CableScreen && screenTile == ((CableScreen)connector).getScreenTile())
+			return true; // Different blocks of the same multiblock screen are allowed to connect to each other
+		// Cables should only be able to connect to screens from the back
+		switch(side) {
+		case EAST:
+			return tile.getBlockMetadata() == EnumFacing.WEST.ordinal();
+		case WEST:
+			return tile.getBlockMetadata() == EnumFacing.EAST.ordinal();
+		case NORTH:
+			return tile.getBlockMetadata() == EnumFacing.SOUTH.ordinal();
+		default:
+			// Screens in RFTools can never actually face up or down, but they can occasionally
+			// be placed such that they face south but their metadata says they face up or down.
+			return tile.getBlockMetadata() == EnumFacing.NORTH.ordinal();
+		}
+	}
+
+	@Override
+	public void destroy() {
+		getWorld().setBlockState(getPos(), Blocks.AIR.getDefaultState(), 3);
+	}
+
+	@Override
+	protected boolean isForceDisconnectable() {
+		return false;
+	}
+
+	@Override
+	protected EnumFacingMap<Boolean> getForceDisconnected() {
+		return null;
+	}
+
+	private long lastUpdated = -1L;
+
+	@Override
+	protected EnumFacingMap<Boolean> getConnected() {
+		if(lastUpdated < getWorld().getTotalWorldTime() && connected.isEmpty()) {
+			lastUpdated = getWorld().getTotalWorldTime();
+			updateConnections();
+		}
+		return connected;
+	}
+
+	@Override
+	protected void markDirty() {
+		tile.markDirty();
+	}
+
+	@Override
+	protected void sendUpdate() {
+		BlockHelpers.markForUpdate(tile.getWorld(), tile.getPos());
+	}
+
+	@Override
+	protected World getWorld() {
+		return tile.getWorld();
+	}
+
+	@Override
+	protected BlockPos getPos() {
+		return tile.getPos();
+	}
+}

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/ModuleDataValue.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/ModuleDataValue.java
@@ -1,0 +1,70 @@
+package org.cyclops.integrateddynamicscompat.modcompat.rftools;
+
+import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
+import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
+import org.cyclops.integrateddynamics.api.evaluate.variable.IValueType;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypes;
+import org.cyclops.integrateddynamicscompat.Reference;
+
+import io.netty.buffer.ByteBuf;
+import mcjty.lib.network.NetworkTools;
+import mcjty.rftools.api.screens.data.IModuleData;
+
+public class ModuleDataValue implements IModuleData {
+	public final IValueType valueType;
+	public final IValue materializedValue;
+	public final String errorMessage;
+
+	public ModuleDataValue(IValue value) {
+		IValue mv = null;
+		try {
+			mv = value.getType().materialize(value);
+		} catch (EvaluationException e) {
+			valueType = null;
+			materializedValue = null;
+			errorMessage = e.getMessage();
+			return;
+		}
+		valueType = mv.getType();
+		materializedValue = mv;
+		errorMessage = null;
+	}
+
+	public ModuleDataValue(String err) {
+		valueType = null;
+		materializedValue = null;
+		errorMessage = err;
+	}
+
+	public ModuleDataValue(ByteBuf buf) {
+		if(buf.readBoolean()) {
+			valueType = ValueTypes.REGISTRY.getValueType(NetworkTools.readString(buf));
+			materializedValue = valueType.deserialize(NetworkTools.readString(buf));
+			errorMessage = null;
+		} else {
+			valueType = null;
+			materializedValue = null;
+			errorMessage = NetworkTools.readString(buf);
+		}
+	}
+	
+	public static final String ID = Reference.MOD_ID + ":module_data_value";
+
+	@Override
+	public String getId() {
+		return ID;
+	}
+
+	@Override
+	public void writeToBuf(ByteBuf buf) {
+		if(materializedValue != null) {
+			buf.writeBoolean(true);
+			NetworkTools.writeString(buf, valueType.getUnlocalizedName());
+			NetworkTools.writeString(buf, valueType.serialize(materializedValue));
+		} else {
+			buf.writeBoolean(false);
+			NetworkTools.writeString(buf, errorMessage);
+		}
+	}
+
+}

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/RFToolsEventHandler.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/RFToolsEventHandler.java
@@ -1,0 +1,31 @@
+package org.cyclops.integrateddynamicscompat.modcompat.rftools;
+
+import org.cyclops.integrateddynamics.item.ItemVariable;
+import org.cyclops.integrateddynamicscompat.Reference;
+
+import mcjty.rftools.blocks.screens.ScreenHitTileEntity;
+import mcjty.rftools.blocks.screens.ScreenTileEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class RFToolsEventHandler {
+	private static final ResourceLocation moduleProviderKey = new ResourceLocation(Reference.MOD_ID, "variable_module_provider");
+
+	@SubscribeEvent
+	public static void onAttachCapabilitiesToItemStack(AttachCapabilitiesEvent<ItemStack> event) {
+		if(event.getObject().getItem() instanceof ItemVariable)
+			event.addCapability(moduleProviderKey, VariableCardCapabilityProvider.INSTANCE);
+	}
+
+	private static final ResourceLocation cableKey = new ResourceLocation(Reference.MOD_ID, "cable");
+
+	@SubscribeEvent
+	public static void onAttachCapabilitiesToTileEntity(AttachCapabilitiesEvent<TileEntity> event) {
+		TileEntity te = event.getObject();
+		if((te instanceof ScreenTileEntity) || (te instanceof ScreenHitTileEntity))
+			event.addCapability(cableKey, new CableNetworkCapabilityProvider(te));
+	}
+}

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/RFToolsModCompat.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/RFToolsModCompat.java
@@ -1,0 +1,56 @@
+package org.cyclops.integrateddynamicscompat.modcompat.rftools;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
+
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.cyclops.cyclopscore.modcompat.IModCompat;
+import org.cyclops.integrateddynamicscompat.Reference;
+
+import mcjty.rftools.api.screens.IScreenModuleRegistry;
+
+/**
+ * Compatibility plugin for RFTools.
+ * @author josephcsible
+ *
+ */
+public class RFToolsModCompat implements IModCompat {
+
+    @Override
+    public String getModID() {
+       return Reference.MOD_RFTOOLS;
+    }
+
+    @Override
+    public void onInit(Step step) {
+    	if(step == Step.PREINIT) {
+    		MinecraftForge.EVENT_BUS.register(RFToolsEventHandler.class);
+            FMLInterModComms.sendFunctionMessage(Reference.MOD_RFTOOLS, "getScreenModuleRegistry", GetScreenModuleRegistry.class.getName());
+    	}
+    }
+
+    @Override
+	public boolean isEnabled() {
+		return true;
+	}
+
+	@Override
+	public String getComment() {
+		return "Support for variable cards in RFTools screens.";
+	}
+	
+    public static class GetScreenModuleRegistry implements Function<IScreenModuleRegistry, Void> {
+        @Nullable
+        @Override
+        public Void apply(IScreenModuleRegistry manager) {
+            manager.registerModuleDataFactory(ModuleDataValue.ID, buf -> {
+                return new ModuleDataValue(buf);
+            });
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/VariableCardCapabilityProvider.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/VariableCardCapabilityProvider.java
@@ -1,0 +1,27 @@
+package org.cyclops.integrateddynamicscompat.modcompat.rftools;
+
+import mcjty.rftools.api.screens.IModuleProvider;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+
+public enum VariableCardCapabilityProvider implements ICapabilityProvider {
+	INSTANCE;
+
+	@CapabilityInject(IModuleProvider.class)
+	private static Capability<IModuleProvider> MODULE_PROVIDER_CAP;
+
+	private final IModuleProvider moduleProvider = VariableCardModuleProvider.INSTANCE;
+
+	@Override
+	public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
+		return capability == MODULE_PROVIDER_CAP;
+	}
+
+	@Override
+	public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
+		return capability == MODULE_PROVIDER_CAP ? (T)moduleProvider : null;
+	}
+
+}

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/VariableCardClientScreenModule.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/VariableCardClientScreenModule.java
@@ -1,0 +1,58 @@
+package org.cyclops.integrateddynamicscompat.modcompat.rftools;
+
+import mcjty.rftools.api.screens.FormatStyle;
+import mcjty.rftools.api.screens.IClientScreenModule;
+import mcjty.rftools.api.screens.IModuleGuiBuilder;
+import mcjty.rftools.api.screens.IModuleRenderHelper;
+import mcjty.rftools.api.screens.ModuleRenderInfo;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class VariableCardClientScreenModule implements IClientScreenModule<ModuleDataValue> {
+    @Override
+    public TransformMode getTransformMode() {
+        return TransformMode.TEXT;
+    }
+
+    @Override
+    public int getHeight() {
+        return 10;
+    }
+
+    @Override
+    public void render(IModuleRenderHelper renderHelper, FontRenderer fontRenderer, int currenty, ModuleDataValue screenData, ModuleRenderInfo renderInfo) {
+        GlStateManager.disableLighting();
+        String text;
+        if(screenData == null) {
+        	text = "screenData is null";
+        }else if(screenData.materializedValue == null) {
+        	text = screenData.errorMessage;
+        } else {
+        	text = screenData.valueType.toCompactString(screenData.materializedValue);
+        }
+        renderHelper.renderText(7, currenty, 0xffffff, renderInfo, renderHelper.format(text, FormatStyle.MODE_FULL));
+    }
+
+    @Override
+    public void mouseClick(World world, int x, int y, boolean clicked) {
+    	// do nothing
+    }
+
+    @Override
+    public void createGui(IModuleGuiBuilder guiBuilder) {
+        guiBuilder.label("TODO").nl();
+    }
+
+    @Override
+    public void setupFromNBT(NBTTagCompound tagCompound, int dim, BlockPos pos) {
+    	// do nothing
+    }
+
+    @Override
+    public boolean needsServerData() {
+        return true;
+    }
+}

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/VariableCardModuleProvider.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/VariableCardModuleProvider.java
@@ -1,0 +1,24 @@
+package org.cyclops.integrateddynamicscompat.modcompat.rftools;
+
+import mcjty.rftools.api.screens.IClientScreenModule;
+import mcjty.rftools.api.screens.IModuleProvider;
+import mcjty.rftools.api.screens.IScreenModule;
+
+public enum VariableCardModuleProvider implements IModuleProvider {
+	INSTANCE;
+
+	@Override
+	public Class<? extends IScreenModule> getServerScreenModule() {
+		return VariableCardScreenModule.class;
+	}
+	
+	@Override
+	public String getName() {
+		return "Card";
+	}
+	
+	@Override
+	public Class<? extends IClientScreenModule> getClientScreenModule() {
+		return VariableCardClientScreenModule.class;
+	}
+};

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/VariableCardScreenModule.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/rftools/VariableCardScreenModule.java
@@ -1,0 +1,54 @@
+package org.cyclops.integrateddynamicscompat.modcompat.rftools;
+
+import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
+import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
+import org.cyclops.integrateddynamics.api.evaluate.variable.IVariable;
+import org.cyclops.integrateddynamics.api.item.IVariableFacade;
+import org.cyclops.integrateddynamics.api.network.INetwork;
+import org.cyclops.integrateddynamics.capability.network.NetworkCarrierConfig;
+import org.cyclops.integrateddynamics.core.helper.NetworkHelpers;
+import org.cyclops.integrateddynamics.core.item.VariableFacadeHandlerRegistry;
+
+import mcjty.rftools.api.screens.IScreenDataHelper;
+import mcjty.rftools.api.screens.IScreenModule;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.common.DimensionManager;
+
+public class VariableCardScreenModule implements IScreenModule<ModuleDataValue> {
+	private TileEntity tile;
+	private IVariableFacade facade;
+
+	@Override
+	public ModuleDataValue getData(IScreenDataHelper helper, World worldObj, long millis) {
+		INetwork network = tile.getCapability(NetworkCarrierConfig.CAPABILITY, null).getNetwork();
+		IVariable variable = facade.getVariable(NetworkHelpers.getPartNetwork(network));
+		IValue value;
+		try {
+			value = variable.getValue();
+		} catch(EvaluationException e) {
+			return new ModuleDataValue(e.getMessage());
+		}
+		return new ModuleDataValue(value);
+	}
+
+	@Override
+	public void setupFromNBT(NBTTagCompound tagCompound, int dim, BlockPos pos) {
+		tile = DimensionManager.getWorld(dim).getTileEntity(pos);
+		facade = VariableFacadeHandlerRegistry.getInstance().handle(tagCompound);
+	}
+
+	@Override
+	public int getRfPerTick() {
+		return 4; // TODO make this configurable
+	}
+
+	@Override
+	public void mouseClick(World world, int x, int y, boolean clicked, EntityPlayer player) {
+		// do nothing
+	}
+
+}


### PR DESCRIPTION
This isn't even close to ready to merge yet. I'm only putting it here for easy review of what I have so far.

Things I need to do/check myself:
- [ ] Fix code formatting/style
- [ ] Don't let very long strings render off the end of the screen
- [ ] Add configuration like color of the displayed text
- [ ] If the variable card has a label, render it
- [ ] Make sure it's normal that screenData is briefly null when loading a saved game, and if so, clean up the message about it
- [ ] Possibly make the RF/tick configurable
- [x] Take out the code that disables a bunch of other compats (just there for now as a convenient workaround for #4)
- [ ] If something like a block is passed, have the option to render the image of the block instead of its name
- [ ] Make sure missing a network is handled sanely

Things I need assistance with/review of:
- [ ] Make sure that the 3 capabilities I add in CableNetworkCapabilityProvider (CableConfig.CAPABILITY, NetworkCarrierConfig.CAPABILITY, PathElementConfig.CAPABILITY) are the right ones to put a part on the network
- [ ] Handle calls to updateConnections() better (in our TileEntities, we call this when the TileEntity is ticked, but I don't think we have that ability when attaching to other mods' TileEntities)
- [ ] When a new screen is placed next to an existing cable, make it connect
- [ ] Make sure I implemented CableScreen.sendUpdate correctly (all other implementations call a method from CyclopsTileEntity, which isn't available on RFTools' tile entities)
- [ ] Should I be materializing the value before I send it to the client? I think so