### PR TITLE
Make duration optional

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/minetweaker/handlers/MechanicalSqueezerHandler.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/minetweaker/handlers/MechanicalSqueezerHandler.java
@@ -36,7 +36,7 @@ public class MechanicalSqueezerHandler extends RecipeRegistryHandler<BlockMechan
 
     @ZenMethod
     public static void addRecipe(IItemStack inputStack,
-                           @Optional IItemStack outputStack, @Optional ILiquidStack outputFluid, int duration) {
+                           @Optional IItemStack outputStack, @Optional ILiquidStack outputFluid, @Optional(valueLong = 10) int duration) {
         addRecipe(inputStack, outputStack, 1.0F, null, 1.0F, null, 1.0F, outputFluid, duration);
     }
 


### PR DESCRIPTION
Fixes this error:
```
[crafttweaker.zenscript.GlobalRegistry:registerNativeClass:98]: java.lang.IllegalArgumentException: All optionals need to be placed at the end of the method declaration: public static void org.cyclops.integrateddynamicscompat.modcompat.minetweaker.handlers.MechanicalSqueezerHandler.addRecipe(crafttweaker.api.item.IItemStack,crafttweaker.api.item.IItemStack,crafttweaker.api.liquid.ILiquidStack,int)
```