### PR TITLE
Remove CompatLayer

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -18,7 +18,6 @@ forestry_version=1.12:5.4.3.129
 charset_version=0.4.0-pre10
 IC2_version=2.8.7-ex112
 top_version=1.12:1.4.11
-compatlayer_version=1.11.2-0.2.9
 refinedstorage_version=1.6.5-283
 ie_version=0.12-64-171
 crafttweakerapi_version=4.1.6.457

--- a/gradle/forge.gradle
+++ b/gradle/forge.gradle
@@ -84,7 +84,6 @@ dependencies {
     deobfCompile "net.industrial-craft:industrialcraft-2:${config.IC2_version}" // http://maven.ic2.player.to/
     deobfCompile "the-one-probe:theoneprobe:${config.top_version}" // https://minecraft.curseforge.com/api/maven/
     //deobfCompile "mcjty.theoneprobe:TheOneProbe:${config.top_version}" // http://maven.tterrag.com/mcjty/theoneprobe/TheOneProbe/
-    deobfCompile "com.github.mcjty:compatlayer:${config.compatlayer_version}" // http://maven.k-4u.nl/com/github/mcjty/compatlayer/
     deobfCompile "refinedstorage:refinedstorage:${config.refinedstorage_version}" // https://repo.raoulvdberge.com/
     deobfCompile "blusunrize:ImmersiveEngineering:${config.ie_version}"// http://maven.blamejared.com/blusunrize/ImmersiveEngineering/
     deobfCompile ("CraftTweaker2:CraftTweaker2-API:${config.crafttweakerapi_version}") { // http://maven.blamejared.com/CraftTweaker2/CraftTweaker2-API/


### PR DESCRIPTION
This mod is to make McJty's mods work on 1.10 and 1.11 with the same jar.
It's not needed or useful in 1.12.