### PR TITLE
WIP: Add OpenComputers compat

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -24,3 +24,4 @@ ie_version=0.12-64-171
 crafttweakerapi_version=4.1.6.457
 crafttweakermain_version=1.12-4.1.6.457
 signals_version=1.12.2:1.1.0-2
+oc_version=MC1.12.2-1.7.2.134

--- a/gradle/forge.gradle
+++ b/gradle/forge.gradle
@@ -49,6 +49,10 @@ repositories {
         name 'K4 maven'
         url "http://maven.k-4u.nl/"
     }
+    maven {
+        name 'OC Repo'
+        url "http://maven.cil.li/"
+    }
 }
 dependencies {
     // Add something like 'integrateddynamics_version_local=0.1.0-DEV' to your gradle.properties if you want to use a custom local Integrated Dynamics version.
@@ -91,6 +95,7 @@ dependencies {
         exclude group: 'org.ow2.asm', module: 'asm-debug-all'
     }
     deobfCompile "signals:Signals-${config.signals_version}:universal"; // http://maven.k-4u.nl/signals/Signals-1.12.2/maven-metadata.xml
+    deobfCompile "li.cil.oc:OpenComputers:${config.oc_version}"; // http://maven.cil.li/li/cil/oc/OpenComputers/maven-metadata.xml
 
     // Only needed for testing
     //deobfCompile "pl.asie.charset:charset-lib:${config.charset_version}" // http://charset.asie.pl/maven/pl/asie/charset/charset-lib/maven-metadata.xml

--- a/src/main/java/org/cyclops/integrateddynamicscompat/IntegratedDynamicsCompat.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/IntegratedDynamicsCompat.java
@@ -37,6 +37,7 @@ import org.cyclops.integrateddynamicscompat.modcompat.immersiveengineering.Immer
 import org.cyclops.integrateddynamicscompat.modcompat.jei.JEIModCompat;
 import org.cyclops.integrateddynamicscompat.modcompat.minetweaker.CraftTweakerModCompat;
 import org.cyclops.integrateddynamicscompat.modcompat.refinedstorage.RefinedStorageModCompat;
+import org.cyclops.integrateddynamicscompat.modcompat.opencomputers.OpenComputersModCompat;
 import org.cyclops.integrateddynamicscompat.modcompat.signals.SignalsModCompat;
 import org.cyclops.integrateddynamicscompat.modcompat.tconstruct.TConstructModCompat;
 import org.cyclops.integrateddynamicscompat.modcompat.tesla.TeslaApiCompat;
@@ -116,6 +117,7 @@ public class IntegratedDynamicsCompat extends ModBaseVersionable {
         modCompatLoader.addModCompat(new ImmersiveEngineeringModCompat());
         modCompatLoader.addModCompat(new CraftTweakerModCompat());
         modCompatLoader.addModCompat(new SignalsModCompat());
+        modCompatLoader.addModCompat(new OpenComputersModCompat());
     }
 
     /**

--- a/src/main/java/org/cyclops/integrateddynamicscompat/Reference.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/Reference.java
@@ -38,6 +38,7 @@ public class Reference {
     public static final String MOD_CRAFTTWEAKER = "crafttweaker";
     public static final String MOD_SIGNALS = "signals";
     public static final String MOD_THAUMCRAFT = "thaumcraft";
+    public static final String MOD_OPENCOMPUTERS = "opencomputers";
     
     // Dependencies
     public static final String MOD_DEPENDENCIES =

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/opencomputers/OpenComputersModCompat.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/opencomputers/OpenComputersModCompat.java
@@ -1,0 +1,29 @@
+package org.cyclops.integrateddynamicscompat.modcompat.opencomputers;
+
+import org.cyclops.cyclopscore.modcompat.IModCompat;
+import org.cyclops.integrateddynamicscompat.Reference;
+
+import li.cil.oc.api.Driver;
+
+public class OpenComputersModCompat implements IModCompat {
+
+	@Override
+	public void onInit(Step initStep) {
+		Driver.add(new ValueInterfaceDriver());
+	}
+
+	@Override
+	public String getModID() {
+		return Reference.MOD_OPENCOMPUTERS;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+
+	@Override
+	public String getComment() {
+		return "Integration for the OpenComputers mod";
+	}
+}

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/opencomputers/ValueInterfaceDriver.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/opencomputers/ValueInterfaceDriver.java
@@ -1,0 +1,223 @@
+package org.cyclops.integrateddynamicscompat.modcompat.opencomputers;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
+import org.cyclops.integrateddynamics.api.evaluate.IValueInterface;
+import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
+import org.cyclops.integrateddynamics.api.evaluate.variable.IValueTypeListProxy;
+import org.cyclops.integrateddynamics.capability.valueinterface.ValueInterfaceConfig;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueObjectTypeBlock.ValueBlock;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueObjectTypeEntity.ValueEntity;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueObjectTypeFluidStack.ValueFluidStack;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueObjectTypeItemStack.ValueItemStack;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeBoolean.ValueBoolean;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeDouble.ValueDouble;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeInteger.ValueInteger;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeList.ValueList;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeLong.ValueLong;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeNbt.ValueNbt;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeString.ValueString;
+
+import com.google.common.collect.ImmutableMap;
+
+import li.cil.oc.api.Network;
+import li.cil.oc.api.driver.DriverBlock;
+import li.cil.oc.api.driver.NamedBlock;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.network.Visibility;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagByte;
+import net.minecraft.nbt.NBTTagByteArray;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagDouble;
+import net.minecraft.nbt.NBTTagFloat;
+import net.minecraft.nbt.NBTTagInt;
+import net.minecraft.nbt.NBTTagIntArray;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTTagLong;
+import net.minecraft.nbt.NBTTagLongArray;
+import net.minecraft.nbt.NBTTagShort;
+import net.minecraft.nbt.NBTTagString;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.FluidStack;
+
+public class ValueInterfaceDriver implements DriverBlock {
+
+	@Override
+	public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
+		TileEntity te = world.getTileEntity(pos);
+		return te != null && te.hasCapability(ValueInterfaceConfig.CAPABILITY, side);
+	}
+
+	@Override
+	public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
+		return new ValueInterfaceManagedEnvironment(world, pos, side);
+	}
+
+	public static class ValueInterfaceManagedEnvironment extends AbstractManagedEnvironment implements NamedBlock {
+		private final World world;
+		private final BlockPos pos;
+		private final EnumFacing side;
+		
+		public ValueInterfaceManagedEnvironment(World world, BlockPos pos, EnumFacing side) {
+			this.world = world;
+			this.pos = pos;
+			this.side = side;
+			setNode(Network.newNode(this, Visibility.Network).withComponent("value_interface").create());
+		}
+		
+		private static final Field longArrayDataField = NBTTagLongArray.class.getDeclaredFields()[0];
+		static {
+			longArrayDataField.setAccessible(true);
+		}
+		
+		private static Object convertNbtForLua(NBTBase nbt) {
+			if(nbt == null) return null;
+			int i;
+			Map<Object, Object> map;
+			switch(nbt.getId()) {
+			case 0: // END
+				return null;
+			case 1: // BYTE
+				return ((NBTTagByte)nbt).getByte();
+			case 2: // SHORT
+				return ((NBTTagShort)nbt).getShort();
+			case 3: // INT
+				return ((NBTTagInt)nbt).getInt();
+			case 4: // LONG
+				return ((NBTTagLong)nbt).getLong();
+			case 5: // FLOAT
+				return ((NBTTagFloat)nbt).getFloat();
+			case 6: // DOUBLE
+				return ((NBTTagDouble)nbt).getDouble();
+			case 7: // BYTE[]
+				return ((NBTTagByteArray)nbt).getByteArray();
+			case 8: // STRING
+				return ((NBTTagString)nbt).getString();
+			case 9: // LIST
+				NBTTagList list = (NBTTagList)nbt;
+				map = new HashMap<>(list.tagCount() + 1);
+				map.put("tagType", NBTBase.NBT_TYPES[list.getTagType()]);
+				i = 0; // first one will actually be 1 because of preincrement
+				for(NBTBase n : list) {
+					map.put(++i, convertNbtForLua(n));
+				}
+				return map;
+			case 10: // COMPOUND
+				NBTTagCompound compound = (NBTTagCompound)nbt;
+				map = new HashMap<>(compound.getSize());
+				for(String key : compound.getKeySet()) {
+					NBTBase tag = compound.getTag(key);
+					map.put(key, ImmutableMap.of(1, NBTBase.NBT_TYPES[tag.getId()], 2, convertNbtForLua(compound.getTag(key))));
+				}
+				return map;
+			case 11: // INT[]
+				return ((NBTTagIntArray)nbt).getIntArray();
+			case 12: // LONG[]
+				try {
+					return longArrayDataField.get(nbt);
+				} catch (IllegalAccessException e) {
+					throw new RuntimeException(e);
+				}
+			}
+			return "UNKNOWN";
+		}
+		
+		private static Object convertValueForLua(IValue value) {
+			if(value instanceof ValueBoolean) {
+				return ((ValueBoolean)value).getRawValue();
+			} else if(value instanceof ValueDouble) {
+				return ((ValueDouble)value).getRawValue();
+			} else if(value instanceof ValueInteger) {
+				return ((ValueInteger)value).getRawValue();
+			} else if(value instanceof ValueLong) {
+				return ((ValueLong)value).getRawValue();
+			} else if(value instanceof ValueString) {
+				return ((ValueString)value).getRawValue();
+			} else if(value instanceof ValueList) {
+				IValueTypeListProxy<?, ?> list = ((ValueList)value).getRawValue();
+				if(!list.isInfinite()) {
+					int len;
+					try {
+						len = list.getLength();
+					} catch (EvaluationException e) {
+						throw new RuntimeException(e);
+					}
+					Map<Object, Object> map = new HashMap<>(len + 1);
+					map.put("valueType", list.getValueType().getTypeName());
+					int i = 0; // first one will actually be 1 because of preincrement
+					for(IValue v : list) {
+						map.put(++i, ImmutableMap.of(1, v.getType().getTypeName(), 2, convertValueForLua(v)));
+					}
+					return map;
+				}
+			} else if(value instanceof ValueNbt) {
+				return convertNbtForLua(((ValueNbt)value).getRawValue());
+			} else if(value instanceof ValueFluidStack) {
+				com.google.common.base.Optional<FluidStack> maybeFluidStack = ((ValueFluidStack)value).getRawValue();
+				if(!maybeFluidStack.isPresent()) return null;
+				FluidStack fluidStack = maybeFluidStack.get();
+				return ImmutableMap.of("name", fluidStack.getFluid().getName(), "amount", fluidStack.amount, "tag", convertNbtForLua(fluidStack.tag));
+			} else if(value instanceof ValueBlock) {
+				com.google.common.base.Optional<IBlockState> maybeState = ((ValueBlock)value).getRawValue();
+				if(!maybeState.isPresent()) return null;
+				IBlockState state = maybeState.get();
+				ImmutableMap<IProperty<?>, Comparable<?>> properties = state.getProperties();
+				Map<Object, Object> luaProperties = new HashMap<>(properties.size());
+				for(Map.Entry<IProperty<?>, Comparable<?>> entry : properties.entrySet()) {
+					IProperty key = entry.getKey();
+					luaProperties.put(key.getName(), key.getName(entry.getValue()));
+				}
+				return ImmutableMap.of("id", state.getBlock().getRegistryName().toString(), "properties", luaProperties);
+			} else if(value instanceof ValueEntity) {
+				com.google.common.base.Optional<UUID> uuid = ((ValueEntity)value).getUuid();
+				if(!uuid.isPresent()) return null;
+				return uuid.get().toString();
+			} else if(value instanceof ValueItemStack) {
+				ItemStack itemStack = ((ValueItemStack)value).getRawValue();
+				return ImmutableMap.of("id", itemStack.getItem().getRegistryName(), "damage", itemStack.getItemDamage(), "count", itemStack.getCount(), "tag", convertNbtForLua(itemStack.getTagCompound()));
+			}
+			return value.getType().toCompactString(value); // TODO handle Operator and Aspect better
+		}
+
+		@Callback(doc = "function():string -- The Integrated Dynamics value being exposed.")
+		public Object[] getValue(Context context, Arguments arguments) throws Exception {
+			TileEntity te = world.getTileEntity(pos);
+			if(te != null) {
+				IValueInterface ivalueinterface = te.getCapability(ValueInterfaceConfig.CAPABILITY, side);
+				if(ivalueinterface != null) {
+					java.util.Optional<IValue> maybeValue = world.getTileEntity(pos).getCapability(ValueInterfaceConfig.CAPABILITY, side).getValue();
+					if(maybeValue.isPresent()) {
+						IValue value = maybeValue.get();
+						return new Object[] {value.getType().getTypeName(), convertValueForLua(value)};
+					}
+				}
+			}
+			return new Object[] {null};
+		}
+
+		@Override
+		public String preferredName() {
+			return "value_interface";
+		}
+
+		@Override
+		public int priority() {
+			return 0;
+		}
+	}
+}


### PR DESCRIPTION
For now, data flow is one way ID -> OC, and neither infinite lists, entities, operators, nor Thaumcraft aspects transfer well.
To use, put something that exposes a value (like a proxy) next to an OC Adapter, then call
`components.value_interface.getValue()` from Lua.