### PR TITLE
More sanity checks for CPacketSetSlot handler.

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamicscompat/network/packet/CPacketSetSlot.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/network/packet/CPacketSetSlot.java
@@ -2,10 +2,12 @@ package org.cyclops.integrateddynamicscompat.network.packet;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import org.cyclops.cyclopscore.inventory.slot.SlotExtended;
 import org.cyclops.cyclopscore.network.CodecField;
 import org.cyclops.cyclopscore.network.PacketCodec;
 import org.cyclops.integrateddynamics.inventory.container.ContainerLogicProgrammerBase;
@@ -46,7 +48,10 @@ public class CPacketSetSlot extends PacketCodec {
     @Override
     public void actionServer(World world, EntityPlayerMP player) {
         if(player.openContainer instanceof ContainerLogicProgrammerBase && player.openContainer.windowId == windowId) {
-            player.openContainer.putStackInSlot(slot, itemStack.copy());
+            if (player.openContainer.inventorySlots.size() <= slot) return;
+            final Slot itemSlot = player.openContainer.getSlot(slot);
+
+            if (itemSlot instanceof SlotExtended && ((SlotExtended) itemSlot).isPhantom()) itemSlot.putStack(itemStack.copy());
         }
     }
 


### PR DESCRIPTION
Adds more sanity checks to the CPacketSetSlot handler, So the item may only be placed in a phantom slot, As well as confirms the slot actually exists, Before inserting the item. The packet can still be modified, However it will only be able to insert items into phantom slots inside the intended GUI, So its potential to spawn actual non-phantom items should theoretically be eliminated.

closes #25, fully resolves #24 .