### PR TITLE
Add Almost Unified integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,8 @@ dependencies {
     implementation("me.shedaniel.cloth:cloth-config-neoforge:$cloth_config_version");
     implementation("dev.architectury:architectury-neoforge:$architectury_version");
 
+    compileOnly "com.almostreliable.mods:almostunified-neoforge:${almostunified_version}:api"
+
     implementation("curse.maven:jade-324717:${jade_version}")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,3 +46,4 @@ ie_version=0.12-90-521
 signals_version=1.12.2:1.1.0-2
 terrablender_version=1.21-4.0.0.1
 jade_version=5884231
+almostunified_version=1.21.1-1.3.0

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/almostunified/AUIntegratedDynamicsConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/almostunified/AUIntegratedDynamicsConfig.java
@@ -1,0 +1,28 @@
+package org.cyclops.integrateddynamicscompat.modcompat.almostunified;
+
+import com.almostreliable.unified.api.plugin.AlmostUnifiedNeoPlugin;
+import com.almostreliable.unified.api.plugin.AlmostUnifiedPlugin;
+import com.almostreliable.unified.api.unification.recipe.RecipeUnifier;
+import com.almostreliable.unified.api.unification.recipe.RecipeUnifierRegistry;
+import net.minecraft.resources.ResourceLocation;
+import org.cyclops.integrateddynamicscompat.Reference;
+
+@AlmostUnifiedNeoPlugin
+public class AUIntegratedDynamicsConfig implements AlmostUnifiedPlugin {
+
+    @Override
+    public ResourceLocation getPluginId() {
+        return ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "main");
+    }
+
+    @Override
+    public void registerRecipeUnifiers(RecipeUnifierRegistry registry) {
+        RecipeUnifier dryingBasinRecipeUnifier = new DryingBasinRecipeUnifier();
+        registry.registerForRecipeType(ResourceLocation.parse("integrateddynamics:drying_basin"), dryingBasinRecipeUnifier);
+        registry.registerForRecipeType(ResourceLocation.parse("integrateddynamics:mechanical_drying_basin"), dryingBasinRecipeUnifier);
+
+        RecipeUnifier squeezerRecipeUnifier = new SqueezerRecipeUnifier();
+        registry.registerForRecipeType(ResourceLocation.parse("integrateddynamics:squeezer"), squeezerRecipeUnifier);
+        registry.registerForRecipeType(ResourceLocation.parse("integrateddynamics:mechanical_squeezer"), squeezerRecipeUnifier);
+    }
+}

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/almostunified/DryingBasinRecipeUnifier.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/almostunified/DryingBasinRecipeUnifier.java
@@ -1,0 +1,17 @@
+package org.cyclops.integrateddynamicscompat.modcompat.almostunified;
+
+import com.almostreliable.unified.api.unification.recipe.RecipeJson;
+import com.almostreliable.unified.api.unification.recipe.RecipeUnifier;
+import com.almostreliable.unified.api.unification.recipe.UnificationHelper;
+
+public class DryingBasinRecipeUnifier implements RecipeUnifier {
+
+    private static final String INPUT_ITEM = "input_item";
+    private static final String OUTPUT_ITEM = "output_item";
+
+    @Override
+    public void unify(UnificationHelper helper, RecipeJson recipe) {
+        helper.unifyInputs(recipe, INPUT_ITEM);
+        helper.unifyOutputs(recipe, OUTPUT_ITEM);
+    }
+}

--- a/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/almostunified/SqueezerRecipeUnifier.java
+++ b/src/main/java/org/cyclops/integrateddynamicscompat/modcompat/almostunified/SqueezerRecipeUnifier.java
@@ -1,0 +1,17 @@
+package org.cyclops.integrateddynamicscompat.modcompat.almostunified;
+
+import com.almostreliable.unified.api.unification.recipe.RecipeJson;
+import com.almostreliable.unified.api.unification.recipe.RecipeUnifier;
+import com.almostreliable.unified.api.unification.recipe.UnificationHelper;
+
+public class SqueezerRecipeUnifier implements RecipeUnifier {
+
+    private static final String INPUT_ITEM = "input_item";
+    private static final String OUTPUT_ITEMS = "output_items";
+
+    @Override
+    public void unify(UnificationHelper helper, RecipeJson recipe) {
+        helper.unifyInputs(recipe, INPUT_ITEM);
+        helper.unifyOutputs(recipe, OUTPUT_ITEMS);
+    }
+}


### PR DESCRIPTION
As mentioned on https://github.com/CyclopsMC/CyclopsCore/pull/215, this pull request introduces integration for [Almost Unified](https://github.com/AlmostReliable/almostunified).

Almost Unified is already capable of transforming your recipe structure; it only needs to know about the recipe keys you used, so two recipe unifiers are sufficient to cover all recipes by Integrated Dynamics. The integration plugin is discovered via the annotation and doesn't need additional registration. The whole implementation is covered by the API, so there shouldn't be any breaking changes in the future.

I hope this solution suits you better than integrating it into your core library.